### PR TITLE
Add favorites and sorting controls to hymn list

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -152,3 +152,66 @@ a:hover{text-decoration:underline}
   vertical-align: middle;
   margin-right: 0.5rem; /* space between logo and text */
 }
+
+/* --- subbar (sort + favorites) --- */
+.subbar{
+  display:flex;
+  align-items:center;
+  justify-content:center;   /* center both controls */
+  gap:1rem;                 /* spacing between dropdown and button */
+  padding:.5rem 1rem;
+  border-bottom:1px solid var(--border);
+  background:var(--card);
+  position:sticky;
+  top:3.25rem;
+  z-index:9;
+}
+.subbar select,
+.subbar button{
+  background:var(--card);
+  color:var(--fg);
+  border:1px solid var(--border);
+  padding:.35rem .6rem;
+  border-radius:.5rem;
+  cursor:pointer;
+}
+.subbar button[aria-pressed="true"]{
+  background:var(--accent);
+  color:#000;
+  border-color:var(--accent);
+}
+
+/* --- star favorite button on each list item --- */
+.hymn-list li{
+  display:flex;
+  align-items:center;
+  gap:.5rem;
+}
+.fav-btn{
+  display:inline-flex;
+  align-items:center;
+  justify-content:center;
+  width:1.75rem;
+  height:1.75rem;
+  border:1px solid var(--border);
+  border-radius:.5rem;
+  background:var(--card);
+  cursor:pointer;
+  flex:0 0 auto;
+}
+.fav-btn .bi{
+  font-size:1rem;
+  line-height:1;
+}
+.fav-btn .bi-star-fill{
+  color:var(--accent);
+}
+.fav-btn:focus{
+  outline:2px solid var(--accent);
+  outline-offset:2px;
+}
+
+/* tighten number/title after we inserted the star button */
+.hymn-no{
+  margin-left:.25rem;
+}

--- a/assets/js/search.js
+++ b/assets/js/search.js
@@ -1,109 +1,246 @@
-import {normalize, STOP} from './utils.js';
+// assets/js/search.js — phrase-by-default + strict mode
+import { normalize } from './utils.js';
 
-/** Build an inverted index with field weights to reduce false positives. */
+/**
+ * Rules:
+ * - If query is a pure number -> exact hymn match fast-path.
+ * - If query has multiple words (ignoring punctuation), treat as a PHRASE by default:
+ *     require that normalized title OR lyrics contain that contiguous phrase.
+ *   (No quotes needed; quotes still work and behave the same.)
+ * - If query is a single word:
+ *     strict match (no OR fallback), with prefix expansion on the last word while typing.
+ * - Scoring: tf-idf with field weights; phrase matches get a big boost.
+ */
+
+const STOPWORDS = new Set([
+  'a','an','and','are','as','at','be','but','by','for','from','had','has','have','he','her','hers','him','his','i',
+  'in','is','it','its','me','my','mine','no','not','of','on','or','our','ours','she','that','the','their','them',
+  'there','they','this','to','us','was','were','what','when','where','which','who','whom','why','with','you','your','yours',
+  'o','oh','hallelujah','amen'
+]);
+
+const WEIGHTS = {
+  title:        3.5,
+  lyrics:       1.0,
+  author:       1.4,
+  tune:         1.4,
+  scripture:    0.8,
+  meter:        0.6,
+  phraseTitle:  12.0,
+  phraseLyrics: 6.0,
+  exactNumber:  1000,
+};
+
+const MAX_PREFIX_EXPANSIONS = 50;
+
+function tokenize(s){
+  const nx = normalize(s);
+  if (!nx) return [];
+  const toks = nx.match(/[a-z0-9]+/g) || [];
+  return toks.filter(t => t.length > 1 && !STOPWORDS.has(t));
+}
+
+function simpleWords(s){
+  // normalized letters/digits/spaces only; collapse spaces
+  const nx = normalize(s);
+  return (nx.replace(/[^a-z0-9 ]+/g,' ').replace(/\s+/g,' ').trim());
+}
+
+function strIncludes(hay, needle){ return hay && needle ? hay.indexOf(needle) !== -1 : false; }
+function log1p(x){ return Math.log(1 + x); }
+
 export function buildIndex(rows){
-  const fieldWeight = { number:5, title:3, author:2, tune:2, meter:1, scripture:1, topics:1, lyrics:1 };
-  const inv = new Map(); // token -> Map(docId -> scoreContribution)
-  const haystack = new Map(); // docId -> normalized full text (for phrase checks)
-  for (const r of rows){
-    const tokensByField = new Map();
-    const addTokens = (field, text) => {
-      if (!text) return;
-      const toks = tokenize(text);
-      tokensByField.set(field, toks);
-      for (const t of toks){
-        if (!t || STOP.has(t)) continue;
-        if (!inv.has(t)) inv.set(t, new Map());
-        const m = inv.get(t);
-        m.set(r.id, (m.get(r.id)||0) + (fieldWeight[field]||1));
-      }
-    };
-    addTokens('number', r.number);
-    addTokens('title', r.title);
-    addTokens('author', r.author);
-    addTokens('tune', r.tune);
-    addTokens('meter', r.meter);
-    addTokens('scripture', r.scripture);
-    addTokens('topics', Array.isArray(r.topics) ? r.topics.join(' ') : r.topics);
-    addTokens('lyrics', r.lyrics);
+  const docs = [];
+  const df = new Map();
+  const vocab = new Set();
 
-    haystack.set(r.id, normalize([r.number, r.title, r.author, r.tune, r.meter, r.scripture, Array.isArray(r.topics)? r.topics.join(' '):r.topics, r.lyrics].filter(Boolean).join('\n')));
+  for (let i = 0; i < rows.length; i++){
+    const r = rows[i] || {};
+    const titleRaw = r.title || '';
+    const lyricsRaw = r.lyrics || '';
+    const authorRaw = r.author || '';
+    const tuneRaw = r.tune || '';
+    const scriptureRaw = r.scripture || '';
+    const meterRaw = r.meter || '';
+
+    const nTitle     = normalize(titleRaw);
+    const nLyrics    = normalize(lyricsRaw);
+    const tfTitle     = countTokens(tokenize(titleRaw));
+    const tfLyrics    = countTokens(tokenize(lyricsRaw));
+    const tfAuthor    = countTokens(tokenize(authorRaw));
+    const tfTune      = countTokens(tokenize(tuneRaw));
+    const tfScripture = countTokens(tokenize(scriptureRaw));
+    const tfMeter     = countTokens(tokenize(meterRaw));
+
+    const seen = new Set([
+      ...Object.keys(tfTitle), ...Object.keys(tfLyrics),
+      ...Object.keys(tfAuthor), ...Object.keys(tfTune),
+      ...Object.keys(tfScripture), ...Object.keys(tfMeter),
+    ]);
+    for (const t of seen){
+      df.set(t, (df.get(t) || 0) + 1);
+      vocab.add(t);
+    }
+
+    docs.push({
+      id: r.id,
+      row: r,
+      num: (r.number ?? '').toString().toLowerCase(),
+      nTitle, nLyrics,
+      tfTitle, tfLyrics, tfAuthor, tfTune, tfScripture, tfMeter,
+      terms: seen,
+    });
   }
-  return {inv, haystack};
+
+  return { N: rows.length, docs, df, vocab };
 }
 
-export function search(index, rows, query){
-  const {tokens, phrases, numberExact} = parseQuery(query);
-  if (!tokens.length && !phrases.length && !numberExact) return rows;
-
-  // AND semantics: start with intersection for tokens
-  let cand = null;
-  for (const t of tokens){
-    const posting = index.inv.get(t);
-    if (!posting) { cand = new Map(); break; } // no docs contain this token
-    const docs = posting;
-    if (cand === null){
-      cand = new Map(docs); // copy
-    } else {
-      const next = new Map();
-      for (const [id,score] of cand){
-        if (docs.has(id)) next.set(id, score + docs.get(id));
-      }
-      cand = next;
-    }
-  }
-  // If no tokens provided, seed with all docs
-  if (cand === null) cand = new Map(rows.map(r=> [r.id, 0]));
-
-  // Phrase filter
-  if (phrases.length){
-    const filtered = new Map();
-    outer: for (const [id,score] of cand){
-      const hay = index.haystack.get(id) || '';
-      for (const p of phrases){
-        if (!hay.includes(p)) continue outer;
-      }
-      filtered.set(id, score + 10*phrases.length);
-    }
-    cand = filtered;
-  }
-
-  // Number exact boost
-  if (numberExact){
-    for (const [id,score] of cand){
-      const r = rowsById(rows).get(id);
-      if (r?.number && normalize(r.number)===numberExact) cand.set(id, score + 25);
-    }
-  }
-
-  const ranked = [...cand.entries()]
-    .sort((a,b)=> b[1]-a[1] || (a[0]>b[0]?1:-1))
-    .map(([id])=> rows.find(r=> r.id===id))
-    .filter(Boolean);
-
-  return ranked;
-}
-
-function rowsById(rows){
-  const m = new Map();
-  for (const r of rows) m.set(r.id, r);
+function countTokens(tokens){
+  const m = Object.create(null);
+  for (const t of tokens){ m[t] = (m[t] || 0) + 1; }
   return m;
 }
 
-function tokenize(text){
-  return normalize(text).replace(/[^a-z0-9\s]/g,' ').split(/\s+/).filter(Boolean);
+function expandPrefix(vocab, prefix){
+  if (!prefix || prefix.length < 2) return [];
+  const out = [];
+  const p = prefix.toLowerCase();
+  let i = 0;
+  for (const t of vocab){
+    if (t.startsWith(p)){
+      out.push(t);
+      if (++i >= MAX_PREFIX_EXPANSIONS) break;
+    }
+  }
+  return out;
 }
 
-function parseQuery(q){
-  const s = normalize(q||'');
-  const phrases = [];
+function hasAllTerms(doc, terms){
+  for (const t of terms) if (!doc.terms.has(t)) return false;
+  return true;
+}
+
+export function search(index, rows, q){
+  const s = (q || '').trim();
+  if (!s) return rows;
+
+  const { N, docs, df, vocab } = index;
+
+  // Extract quoted phrases (still honored)
   const phraseRe = /"([^"]+)"/g;
-  let m; let rest = s;
-  while ((m = phraseRe.exec(s))){
-    phrases.push(m[1]);
+  const quotedPhrases = [];
+  let m;
+  while ((m = phraseRe.exec(s))) quotedPhrases.push(m[1]);
+  const nQuotedPhrases = quotedPhrases.map(p => simpleWords(p)).filter(Boolean);
+
+  // Remaining text (unquoted)
+  const rest = s.replace(phraseRe, ' ').trim();
+
+  // Pure number? exact match fast-path
+  if (/^\d+$/.test(rest)){
+    const want = rest.toLowerCase();
+    const hit = docs.find(d => d.num === want);
+    if (hit) return [hit.row];
+    // strict: fall through to other logic if not found
   }
-  rest = s.replace(phraseRe, ' ').trim();
-  const tokens = tokenize(rest).filter(t=> !STOP.has(t));
-  const numberExact = /^\d+$/.test(rest) ? rest : null;
-  return {tokens, phrases, numberExact};
+
+  // Decide mode: phrase-by-default when multi-word input (ignoring punctuation)
+  const cleaned = simpleWords(rest);              // e.g., "thine the glory"
+  const hasSpace = cleaned.includes(' ');
+  const defaultPhrase = hasSpace ? cleaned : null;
+
+  // Token set for single-word strict search
+  const terms = tokenize(rest);
+
+  const results = [];
+  for (const doc of docs){
+    // 1) All quoted phrases must appear (title or lyrics)
+    let pass = true;
+    for (const ph of nQuotedPhrases){
+      if (!(strIncludes(doc.nTitle, ph) || strIncludes(doc.nLyrics, ph))){ pass = false; break; }
+    }
+    if (!pass) continue;
+
+    // 2) If defaultPhrase is set (multi-word query without quotes), REQUIRE that phrase too
+    if (defaultPhrase){
+      if (!(strIncludes(doc.nTitle, defaultPhrase) || strIncludes(doc.nLyrics, defaultPhrase))) continue;
+    } else {
+      // Single-word strict: require that term (with prefix expansion while typing)
+      if (terms.length){
+        const last = terms[terms.length - 1];
+        const expansions = expandPrefix(vocab, last);
+        const required = terms.slice(0, -1); // earlier tokens must all be present (usually none for single-word)
+        if (!hasAllTerms(doc, required)) continue;
+
+        if (expansions.length){
+          // last must match at least one expansion
+          let ok = false;
+          for (const t of expansions){ if (doc.terms.has(t)) { ok = true; break; } }
+          if (!ok) continue;
+        } else {
+          // no expansions → the last must be present exactly
+          if (!doc.terms.has(last)) continue;
+        }
+      }
+    }
+
+    // Score
+    let score = 0;
+
+    // Phrase boosts
+    for (const ph of nQuotedPhrases){
+      if (strIncludes(doc.nTitle, ph))  score += WEIGHTS.phraseTitle;
+      if (strIncludes(doc.nLyrics, ph)) score += WEIGHTS.phraseLyrics;
+    }
+    if (defaultPhrase){
+      if (strIncludes(doc.nTitle, defaultPhrase))  score += WEIGHTS.phraseTitle;
+      if (strIncludes(doc.nLyrics, defaultPhrase)) score += WEIGHTS.phraseLyrics;
+    }
+
+    // TF-IDF scoring for terms (helps ranking among equals)
+    const termSet = new Set(terms);
+    for (const t of termSet){
+      const idf = log1p(N / ((df.get(t) || 0) + 1));
+      const tfT = doc.tfTitle[t]     || 0;
+      const tfL = doc.tfLyrics[t]    || 0;
+      const tfA = doc.tfAuthor[t]    || 0;
+      const tfU = doc.tfTune[t]      || 0;
+      const tfS = doc.tfScripture[t] || 0;
+      const tfM = doc.tfMeter[t]     || 0;
+
+      const fieldSum =
+        WEIGHTS.title     * Math.sqrt(tfT) +
+        WEIGHTS.lyrics    * Math.sqrt(tfL) +
+        WEIGHTS.author    * Math.sqrt(tfA) +
+        WEIGHTS.tune      * Math.sqrt(tfU) +
+        WEIGHTS.scripture * Math.sqrt(tfS) +
+        WEIGHTS.meter     * Math.sqrt(tfM);
+
+      score += idf * fieldSum;
+    }
+
+    // Extra nudge if a number was in the text and exactly matches this hymn
+    if (/\b\d+\b/.test(rest) && doc.num === rest.toLowerCase()){
+      score += WEIGHTS.exactNumber;
+    }
+
+    if (score > 0) results.push({ row: doc.row, score });
+  }
+
+  results.sort((a,b)=> b.score - a.score || numAsc(a.row,b.row) || titleAsc(a.row,b.row));
+  return results.map(r => r.row);
+}
+
+function numAsc(a,b){
+  const an = parseInt((a.number ?? '0'), 10);
+  const bn = parseInt((b.number ?? '0'), 10);
+  if (Number.isNaN(an) && Number.isNaN(bn)) return 0;
+  if (Number.isNaN(an)) return 1;
+  if (Number.isNaN(bn)) return -1;
+  return an - bn;
+}
+function titleAsc(a,b){
+  const at = (a.title || '').toLowerCase();
+  const bt = (b.title || '').toLowerCase();
+  return at < bt ? -1 : at > bt ? 1 : 0;
 }

--- a/index.html
+++ b/index.html
@@ -9,27 +9,9 @@
   <title>Hymns from Gravel Hill</title>
   
   <link rel="stylesheet" href="assets/css/style.css">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">
   <meta name="theme-color" content="#0b0b0c">
 
-  <!-- Open Graph / Facebook / Messenger / WhatsApp 
-<link rel="canonical" href="https://hymns.fromgravelhill.ca/" />
-
-<meta property="og:title" content="Hymns from Gravel Hill" />
-<meta property="og:description" content="Browse and search hymn books online." />
-<meta property="og:type" content="website" />
-<meta property="og:url" content="https://hymns.fromgravelhill.ca/" />
-
-<meta property="og:image" content="https://hymns.fromgravelhill.ca/assets/img/share.jpg" />
-<meta property="og:image:secure_url" content="https://hymns.fromgravelhill.ca/assets/img/share.jpg" />
-<meta property="og:image:width" content="1200" />
-<meta property="og:image:height" content="630" />
-<meta property="og:image:alt" content="Hymns from Gravel Hill" />
-
-Twitter (WhatsApp ignores these, but keep for others)
-<meta name="twitter:card" content="summary_large_image" />
-<meta name="twitter:title" content="Hymns from Gravel Hill" />
-<meta name="twitter:description" content="Browse and search hymn books online." />
-<meta name="twitter:image" content="https://hymns.fromgravelhill.ca/assets/img/share.jpg" /> -->
 
 <!-- Open Graph -->
 <meta property="og:title" content="Hymns from Gravel Hill" />
@@ -44,7 +26,7 @@ Twitter (WhatsApp ignores these, but keep for others)
 <meta name="twitter:card" content="summary_large_image" />
 <meta name="twitter:title" content="Hymns from Gravel Hill" />
 <meta name="twitter:description" content="Browse and search hymn books online" />
-<meta name="twitter:image" content="{{ '/assets/img/hare.jpg' | relative_url }}" />
+<meta name="twitter:image" content="{{ '/assets/img/share.jpg' | relative_url }}" />
 
 
 <!-- Favicon -->
@@ -65,6 +47,19 @@ Twitter (WhatsApp ignores these, but keep for others)
     </nav>
   </header>
 
+<nav class="subbar" id="sortFavBar" aria-label="List controls">
+  <div class="left">
+    <label for="sortSelect" class="sr-only">Sort</label>
+    <select id="sortSelect">
+      <option value="number">Sort: Number (default)</option>
+      <option value="alpha">Sort: Alphabetical</option>
+    </select>
+  </div>
+  <div class="right">
+    <button id="favoritesToggle" aria-pressed="false" title="Show only favorites">Show Favorites (0)</button>
+  </div>
+</nav>
+  
   <main class="container">
     <section class="content" id="listView" aria-label="Hymn list">
       <div id="resultStats" class="muted"></div>


### PR DESCRIPTION
Introduces a subbar UI with sort and favorites toggle, star favorite buttons for each hymn, and persistent favorites per dataset. Updates search logic for phrase-by-default and strict single-word matching, and refactors rendering to support sorting and favorites filtering. Also adds Bootstrap Icons for star buttons and updates Open Graph image reference.